### PR TITLE
v2.2.1 — Fix spiral-arm detection: parastichy family selection + smooth spiral extensions

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.1.0",
       "dependencies": {
         "fast-prime-gen": "^1.0.0",
-        "next": "15.4.10",
-        "postcss": "^8.5.3",
+        "next": "15.5.18",
+        "postcss": "^8.5.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "three": "^0.174.0"
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.10.tgz",
-      "integrity": "sha512-knhmoJ0Vv7VRf6pZEPSnciUG1S4bIhWx+qTYBW/AjxEtlzsiNORPk8sFDCEvqLfmKuey56UB9FL1UdHEV3uBrg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.8.tgz",
-      "integrity": "sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.8.tgz",
-      "integrity": "sha512-xla6AOfz68a6kq3gRQccWEvFC/VRGJmA/QuSLENSO7CZX5WIEkSz7r1FdXUjtGCQ1c2M+ndUAH7opdfLK1PQbw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -806,11 +806,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.8.tgz",
-      "integrity": "sha512-y3fmp+1Px/SJD+5ntve5QLZnGLycsxsVPkTzAc3zUiXYSOlTPqT8ynfmt6tt4fSo1tAhDPmryXpYKEAcoAPDJw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -822,11 +825,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.8.tgz",
-      "integrity": "sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -838,11 +844,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.8.tgz",
-      "integrity": "sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -854,11 +863,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.8.tgz",
-      "integrity": "sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -870,9 +882,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.8.tgz",
-      "integrity": "sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -886,9 +898,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.8.tgz",
-      "integrity": "sha512-Exsmf/+42fWVnLMaZHzshukTBxZrSwuuLKFvqhGHJ+mC1AokqieLY/XzAl3jc/CqhXLqLY3RRjkKJ9YnLPcRWg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -4396,9 +4408,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -4421,12 +4433,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.10.tgz",
-      "integrity": "sha512-itVlc79QjpKMFMRhP+kbGKaSG/gZM6RCvwhEbwmCNF06CdDiNaoHcbeg0PqkEa2GOcn8KJ0nnc7+yL7EjoYLHQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.10",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4439,14 +4451,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.8",
-        "@next/swc-darwin-x64": "15.4.8",
-        "@next/swc-linux-arm64-gnu": "15.4.8",
-        "@next/swc-linux-arm64-musl": "15.4.8",
-        "@next/swc-linux-x64-gnu": "15.4.8",
-        "@next/swc-linux-x64-musl": "15.4.8",
-        "@next/swc-win32-arm64-msvc": "15.4.8",
-        "@next/swc-win32-x64-msvc": "15.4.8",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -4761,9 +4773,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4780,7 +4792,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prime-visualizer",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prime-visualizer",
-      "version": "2.1.0",
+      "version": "2.2.1",
       "dependencies": {
         "fast-prime-gen": "^1.0.0",
         "next": "15.5.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prime-visualizer",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "author": {
     "name": "Arun Gupta"
   },

--- a/src/components/PrimeVisualization.tsx
+++ b/src/components/PrimeVisualization.tsx
@@ -5,7 +5,7 @@ import { getPrimes } from '../lib/primes';
 import { makePredictor } from '../lib/prediction';
 import { armColor, computeColors, computeDim, ColorMode, HighlightSpec, Theme } from '../lib/colors';
 import {
-  armStructure,
+  armCandidates,
   calculateAccuracy,
   detectSpiralArms,
   layoutExtent,
@@ -43,6 +43,7 @@ interface PrimeVisualizationProps {
   fibChords: boolean;
   fibLag: number;
   customFormulas: CustomFormulas;
+  armFamily: number | null; // selected arm period; null = parastichy auto
   position: { x: number; y: number; z: number };
   ref?: React.Ref<PrimeVizHandle>;
 }
@@ -98,6 +99,7 @@ const PrimeVisualization: React.FC<PrimeVisualizationProps> = ({
   fibChords,
   fibLag,
   customFormulas,
+  armFamily,
   position,
   ref,
 }) => {
@@ -142,9 +144,13 @@ const PrimeVisualization: React.FC<PrimeVisualizationProps> = ({
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
   const [selected, setSelected] = useState<number | null>(null);
 
-  // The arm structure the current point count can resolve. Falls back to the
-  // naive divisor only when no convergent fits (too few primes to show any arm).
-  const structure = useMemo(() => armStructure(angleDelta, primes.length), [angleDelta, primes.length]);
+  // All arm families this data can show, parastichy-dominant first; the user
+  // can pin an alternate family via armFamily
+  const candidates = useMemo(() => armCandidates(angleDelta, primes.length), [angleDelta, primes.length]);
+  const structure = useMemo(
+    () => candidates.find(c => c.period === armFamily) ?? candidates[0] ?? null,
+    [candidates, armFamily]
+  );
   const stepsPerRotation = structure?.period ?? Math.max(1, Math.round(360 / angleDelta));
   const valueLayout = VALUE_LAYOUTS.has(layout);
   const mapper = useMemo(
@@ -182,7 +188,7 @@ const PrimeVisualization: React.FC<PrimeVisualizationProps> = ({
     const armCount = Math.min(period, Math.ceil(primes.length / 2));
     const effectivePredictionCount = Math.max(1, Math.min(predictionCount, Math.floor(6000 / Math.max(armCount, 1))));
 
-    const arms = detectSpiralArms(primes, period, effectivePredictionCount);
+    const arms = detectSpiralArms(primes, period, effectivePredictionCount, driftDeg);
 
     // ponytail: capped at the 200k-th prime — beyond that, far predictions still
     // render from the model, they just lose their green "actual" comparison
@@ -720,6 +726,29 @@ const PrimeVisualization: React.FC<PrimeVisualizationProps> = ({
       // curves would be spaghetti — draw only the predicted/actual markers there
       const drawArmCurves = !valueLayout;
 
+      // Maps a fractional-index extension sample onto the arm's VISUAL path:
+      // the angle advances by drift per period step (integer steps agree with
+      // the standard mapper mod 2π, but fractional indices through the mapper
+      // would wind through every intermediate turn and scribble across the
+      // scene). Radius/height follow the layout's own formulas.
+      const rad = (angleDelta * Math.PI) / 180;
+      const driftRad = (analysis.driftDeg * Math.PI) / 180;
+      const pLastAll = primes[primes.length - 1];
+      const zStepHelix = (6 * Math.log(pLastAll)) / Math.max(primes.length, 1);
+      const armPathVec = (anchorIndex: number, index: number, prime: number): THREE.Vector3 => {
+        const t = (index - anchorIndex) / analysis.period;
+        const theta = anchorIndex * rad + t * driftRad;
+        let r = 0.01 * prime;
+        let z = 0;
+        if (layout === 'helix') {
+          r = 1.5 * Math.log(prime);
+          z = zStepHelix * index;
+        } else if (layout === 'residual') {
+          r = 0.01 * smooth(index); // predictions ride the reference sheet (z ≈ 0)
+        }
+        return new THREE.Vector3(r * Math.cos(theta), r * Math.sin(theta), z);
+      };
+
       arms.forEach(arm => {
         const hue = armColor(arm.armIndex, analysis.period, theme);
         const armPoints = arm.points.map(p => vec(p.index, p.prime));
@@ -738,17 +767,15 @@ const PrimeVisualization: React.FC<PrimeVisualizationProps> = ({
         }
 
         if (arm.predictions.length > 0) {
-          if (drawArmCurves) {
-            // Smooth extension from the last few arm points through the predictions
-            const transitionPoints = armPoints.slice(-Math.min(3, armPoints.length));
-            arm.predictions.forEach(p => transitionPoints.push(vec(p.index, p.prime)));
-
-            const predCurvePoints =
-              transitionPoints.length >= 3
-                ? new THREE.CatmullRomCurve3(transitionPoints, false, 'catmullrom', 0.5).getPoints(transitionPoints.length * 10)
-                : transitionPoints;
+          if (drawArmCurves && arm.extensionPath.length > 0) {
+            // The extension continues the arm's precessing path smoothly
+            const anchor = arm.points[arm.points.length - 1].index;
+            const extPoints = [
+              armPoints[armPoints.length - 1],
+              ...arm.extensionPath.map(p => armPathVec(anchor, p.index, p.prime)),
+            ];
             const predLine = new THREE.Line(
-              new THREE.BufferGeometry().setFromPoints(predCurvePoints),
+              new THREE.BufferGeometry().setFromPoints(extPoints),
               new THREE.LineBasicMaterial({ color: 0xff3333, transparent: true, opacity: 0.7 })
             );
             predictionGroup.add(predLine);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ColorMode, Theme } from '../lib/colors';
-import { armStructure, compileFormula, ArmStructure, CustomFormulas, CUSTOM_PRESETS, Layout, VALUE_LAYOUTS } from '../lib/arms';
+import { compileFormula, ArmCandidate, ArmStructure, CustomFormulas, CUSTOM_PRESETS, Layout, VALUE_LAYOUTS } from '../lib/arms';
 import {
   ChipButton,
   FineSlider,
@@ -37,6 +37,9 @@ interface SidebarProps {
   fibLag: number;
   showModelCurve: boolean;
   customFormulas: CustomFormulas;
+  candidates: ArmCandidate[];
+  armFamily: number | null;
+  onArmFamilyChange: (period: number | null) => void;
   onPrimeCountCommit: (count: number) => void;
   onAngleDeltaChange: (deg: number) => void;
   onPredictionCountChange: (count: number) => void;
@@ -93,9 +96,17 @@ const RESIDUE_CLASSES: Record<number, number[]> = {
 
 const describeArms = (arms: ArmStructure | null): string => {
   if (!arms) return 'too few primes to resolve an arm';
+  if (arms.period === 1) return `single spiral — ${arms.driftDeg.toFixed(2)}°/step`;
   if (arms.driftDeg === 0) return `${arms.period} arms — exact rays`;
   const sign = arms.driftDeg > 0 ? '+' : '';
   return `${arms.period} arms — precessing ${sign}${arms.driftDeg.toFixed(2)}°/step`;
+};
+
+// Compact chip label for one arm family
+const familyLabel = (c: ArmCandidate): string => {
+  if (c.period === 1) return '1 spiral';
+  if (c.driftDeg === 0) return `${c.period} rays`;
+  return `${c.period} · ${c.driftDeg > 0 ? '+' : ''}${c.driftDeg.toFixed(1)}°`;
 };
 
 const SecondaryButton: React.FC<{ onClick: () => void; children: React.ReactNode }> = ({ onClick, children }) => (
@@ -156,6 +167,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   fibLag,
   showModelCurve,
   customFormulas,
+  candidates,
+  armFamily,
+  onArmFamilyChange,
   onPrimeCountCommit,
   onAngleDeltaChange,
   onPredictionCountChange,
@@ -194,7 +208,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   // Arms exist at every angle; which N you see depends on how many primes are on
   // screen (best rational approximation of Δ/360 that still fills each arm)
-  const arms = armStructure(angleDelta, primeCount);
+  const arms = candidates.find(c => c.period === armFamily) ?? candidates[0] ?? null;
 
   // Mobile drawer touch handling
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -398,6 +412,26 @@ const Sidebar: React.FC<SidebarProps> = ({
           </Section>
 
           <Section title="analysis">
+            {!angleUnused && candidates.length > 1 && (
+              <div>
+                <div className={`${LABEL} mb-1 normal-case tracking-normal`}>Arm family</div>
+                <div className="flex flex-wrap gap-1">
+                  <ChipButton active={armFamily === null} onClick={() => onArmFamilyChange(null)} title="Parastichy-dominant family (what the eye picks out)">
+                    Auto
+                  </ChipButton>
+                  {candidates.slice(0, 4).map(c => (
+                    <ChipButton
+                      key={c.period}
+                      active={armFamily === c.period}
+                      onClick={() => onArmFamilyChange(c.period)}
+                      title={`${c.pointsPerArm} points per arm`}
+                    >
+                      {familyLabel(c)}
+                    </ChipButton>
+                  ))}
+                </div>
+              </div>
+            )}
             <Toggle id="showPredictions" label="Spiral-arm predictions" checked={showPredictions} onChange={onTogglePredictions} />
             {showPredictions && (
               <div>

--- a/src/components/ThreeGrid.tsx
+++ b/src/components/ThreeGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { firstPrimes } from '../lib/primes';
 import { ColorMode, HighlightSpec, Theme } from '../lib/colors';
-import { armStructure, CustomFormulas, DEFAULT_CUSTOM, Layout } from '../lib/arms';
+import { armCandidates, CustomFormulas, DEFAULT_CUSTOM, Layout } from '../lib/arms';
 import Sidebar, { Residue } from './Sidebar';
 import StatsStrip from './overlays/StatsStrip';
 import Legend from './overlays/Legend';
@@ -31,6 +31,7 @@ const ThreeGrid: React.FC<ThreeGridProps> = ({ width, height }) => {
   const [fibChords, setFibChords] = useState(false);
   const [fibLag, setFibLag] = useState(8);
   const [customFormulas, setCustomFormulas] = useState<CustomFormulas>(DEFAULT_CUSTOM);
+  const [armFamily, setArmFamily] = useState<number | null>(null); // null = parastichy auto
   const [showModelCurve, setShowModelCurve] = useState(false);
   const [primes, setPrimes] = useState<number[]>([]);
   const vizRef = useRef<PrimeVizHandle>(null);
@@ -77,8 +78,14 @@ const ThreeGrid: React.FC<ThreeGridProps> = ({ width, height }) => {
 
   // Same arm structure the visualization uses, so the legend's "index mod N"
   // matches the hues actually drawn
-  const stepsPerRotation =
-    armStructure(angleDelta, primes.length)?.period ?? Math.max(1, Math.round(360 / angleDelta));
+  const candidates = useMemo(() => armCandidates(angleDelta, primes.length), [angleDelta, primes.length]);
+  const resolvedArm = candidates.find(c => c.period === armFamily) ?? candidates[0] ?? null;
+  const stepsPerRotation = resolvedArm?.period ?? Math.max(1, Math.round(360 / angleDelta));
+
+  // A pinned family is meaningless once the angle or data changes
+  useEffect(() => {
+    setArmFamily(null);
+  }, [angleDelta, primeCount]);
 
   return (
     <div
@@ -103,6 +110,7 @@ const ThreeGrid: React.FC<ThreeGridProps> = ({ width, height }) => {
         fibChords={fibChords}
         fibLag={fibLag}
         customFormulas={customFormulas}
+        armFamily={armFamily}
         position={position}
       />
       <StatsStrip primes={primes} isComputing={isComputing} />
@@ -129,6 +137,9 @@ const ThreeGrid: React.FC<ThreeGridProps> = ({ width, height }) => {
         fibLag={fibLag}
         showModelCurve={showModelCurve}
         customFormulas={customFormulas}
+        candidates={candidates}
+        armFamily={armFamily}
+        onArmFamilyChange={setArmFamily}
         onPrimeCountCommit={setPrimeCount}
         onAngleDeltaChange={setAngleDelta}
         onPredictionCountChange={setPredictionCount}

--- a/src/lib/arms.ts
+++ b/src/lib/arms.ts
@@ -1,4 +1,4 @@
-import { makeArmPredictor, makePredictor } from './prediction';
+import { makeArmPredictor, makePredictor, nthPrimeEstimate } from './prediction';
 
 // Spiral-arm math, extracted from the visualization component: residue-class
 // arm detection, hybrid prediction, accuracy scoring, and the layout mappers.
@@ -19,6 +19,7 @@ export interface SpiralArm {
   armIndex: number; // The residue class (0 to stepsPerRotation-1)
   points: ArmPoint[];
   predictions: ArmPoint[]; // future points on the arm, prime = predicted value
+  extensionPath: ArmPoint[]; // dense fractional-index samples along the precessing arm
 }
 
 export interface PredictionAccuracy {
@@ -41,30 +42,45 @@ export const EMPTY_ACCURACY: PredictionAccuracy = {
 // set by how close N·Δ lands to a whole number of turns; the leftover is the
 // per-step drift, and the arm precesses by that much as it grows outward.
 //
-// Rounding 360/Δ picks a bad N whenever Δ doesn't divide 360 — at 37.2° it gives
-// N=10, which overshoots by 12° per step, so the "arm" coils around the origin
-// instead of radiating out. But arms exist at EVERY angle: the good N are the
-// denominators of the continued-fraction convergents of Δ/360, i.e. the best
-// rational approximations. At 37.2° those are 9, 10, 29, 300 with drifts −25.2°,
-// 12°, −1.2°, 0° — N=29 is the structure the eye actually picks out. At the
-// golden angle they are the Fibonacci numbers, which is why a sunflower shows
-// 34/55/89 spirals.
+// Arms exist at EVERY angle, one family per (semi)convergent denominator of
+// Δ/360, and the family the EYE picks out is scale-dependent: the parastichy
+// problem from phyllotaxis (Vogel/Ridley — why a sunflower shows 21/34/55
+// spirals as it grows). The dominant family minimizes the spacing between
+// CONSECUTIVE points on the same arm, measured where most points live. Picking
+// the most exact family instead (the old behavior) yields the straightest but
+// stubbiest arms — a starburst of 4-point rays at Δ=35° where the eye plainly
+// sees 10 sweeping spirals.
 //
-// Integer math on the entered angle (at most 3 decimals) keeps this exact.
+// Integer math on the entered angle (at most 3 decimals) keeps drift exact.
 const ANGLE_SCALE = 1000;
 const FULL_TURN = 360 * ANGLE_SCALE;
 
 // Fewer points than this and an arm doesn't read as one
-const MIN_POINTS_PER_ARM = 3;
+const MIN_POINTS_PER_ARM = 5;
+
+// Beyond this per-step precession the eye no longer chains points into an arm.
+// Never changes a winner (validated) — it keeps the alternates list honest.
+const MAX_DRIFT_DEG = 60;
+
+// Where along the sequence the score is evaluated (outer-biased: the eye reads
+// structure at the rim). The one perceptual knob — 0.5 and 0.8 both mis-pick
+// (validated against browser observations at 35°, 37.2°, 110°, φ).
+const REP_FRAC = 0.6;
 
 export interface ArmStructure {
   period: number; // N — indices N apart share an arm
   driftDeg: number; // signed precession per step; 0 means an exact ray
 }
 
-// Denominators of the continued-fraction convergents of n/d, increasing.
-// Recurrence: q₋₂ = 1, q₋₁ = 0, qₖ = aₖ·qₖ₋₁ + qₖ₋₂
-const convergentDenominators = (n: number, d: number): number[] => {
+export interface ArmCandidate extends ArmStructure {
+  pointsPerArm: number;
+  score: number; // within-arm neighbor spacing at the representative radius
+}
+
+// Denominators of ALL semiconvergents of n/d (every best one-sided rational
+// approximation): during the CF recurrence with partial quotient a, emit
+// q = j·qₖ₋₁ + qₖ₋₂ for j = 1..a.
+const semiconvergentDenominators = (n: number, d: number): number[] => {
   const denominators: number[] = [];
   let qPrev2 = 1;
   let qPrev1 = 0;
@@ -73,12 +89,14 @@ const convergentDenominators = (n: number, d: number): number[] => {
   while (den !== 0) {
     const a = Math.floor(num / den);
     [num, den] = [den, num - a * den];
-    const q = a * qPrev1 + qPrev2;
+    for (let j = 1; j <= a; j++) {
+      denominators.push(j * qPrev1 + qPrev2);
+    }
+    const qk = a * qPrev1 + qPrev2;
     qPrev2 = qPrev1;
-    qPrev1 = q;
-    denominators.push(q);
+    qPrev1 = qk;
   }
-  return denominators;
+  return [...new Set(denominators)];
 };
 
 // Signed drift of a period-N arm, in degrees, within (−180, 180]
@@ -88,21 +106,44 @@ const driftDegrees = (period: number, n: number): number => {
   return r / ANGLE_SCALE;
 };
 
-// The tightest arm structure this many primes can actually show: the largest
-// convergent denominator (best approximation ⇒ least drift) that still leaves
-// MIN_POINTS_PER_ARM points per arm. Null when even the coarsest doesn't fit.
-export const armStructure = (angleDelta: number, primeCount: number): ArmStructure | null => {
+// All arm families this many primes can show, best (parastichy-dominant) first.
+// Score = distance between consecutive points on one arm at the representative
+// radius: radial step 0.01·q·ln(p) + tangential step r·|drift|.
+export const armCandidates = (angleDelta: number, primeCount: number): ArmCandidate[] => {
   const n = Math.round(angleDelta * ANGLE_SCALE);
-  if (n <= 0) return null;
+  if (n <= 0 || primeCount < MIN_POINTS_PER_ARM) return [];
 
   const maxPeriod = Math.floor(primeCount / MIN_POINTS_PER_ARM);
+  const pRep = nthPrimeEstimate(Math.max(6, Math.floor(REP_FRAC * primeCount)));
+  const rRep = 0.01 * pRep;
+  const meanGap = Math.log(pRep);
 
-  let period: number | null = null;
-  for (const q of convergentDenominators(n, FULL_TURN)) {
-    if (q >= 2 && q <= maxPeriod) period = q; // later convergents approximate better
-  }
-  return period === null ? null : { period, driftDeg: driftDegrees(period, n) };
+  const toCandidate = (q: number): ArmCandidate => {
+    const driftDeg = driftDegrees(q, n);
+    const radial = 0.01 * q * meanGap;
+    const tangential = rRep * Math.abs((driftDeg * Math.PI) / 180);
+    return {
+      period: q,
+      driftDeg,
+      pointsPerArm: Math.ceil(primeCount / q),
+      score: Math.hypot(radial, tangential),
+    };
+  };
+
+  const all = semiconvergentDenominators(n, FULL_TURN)
+    .filter(q => q >= 1 && q <= maxPeriod)
+    .map(toCandidate);
+
+  const capped = all.filter(c => Math.abs(c.driftDeg) <= MAX_DRIFT_DEG);
+  // The cap only empties the list at tiny prime counts — show something anyway
+  const pool = capped.length > 0 ? capped : all;
+
+  return pool.sort((a, b) => a.score - b.score);
 };
+
+// The family the eye picks out — the parastichy-dominant candidate
+export const armStructure = (angleDelta: number, primeCount: number): ArmStructure | null =>
+  armCandidates(angleDelta, primeCount)[0] ?? null;
 
 // Maps a (index, prime) pair to scene coordinates for the active layout.
 // Index may be fractional (used to sample smooth curves between points).
@@ -306,13 +347,16 @@ export const makeMapper = (
 // known exactly (index + k·stepsPerRotation); only the prime's magnitude needs
 // predicting — `predict` is the hybrid model: globally anchored inverse
 // Riemann-R plus this arm's own shrunken offset (see src/lib/prediction.ts).
+// Also returns a dense fractional-index path along the same precessing arm so
+// the extension renders as a smooth spiral, not a chord through sparse points.
 const predictArmExtension = (
   points: ArmPoint[],
   stepsPerRotation: number,
   numPredictions: number,
-  predict: (j: number) => number
-): ArmPoint[] => {
-  if (points.length < 2) return [];
+  predict: (j: number) => number,
+  driftDeg: number
+): { predictions: ArmPoint[]; extensionPath: ArmPoint[] } => {
+  if (points.length < 2) return { predictions: [], extensionPath: [] };
 
   const lastPoint = points[points.length - 1];
   const predictions: ArmPoint[] = [];
@@ -320,15 +364,27 @@ const predictArmExtension = (
     const index = lastPoint.index + step * stepsPerRotation;
     predictions.push({ index, prime: Math.round(predict(index)) });
   }
-  return predictions;
+
+  // Adaptive sampling: an exact ray (drift 0) is a straight line — 1 sample per
+  // step; a fast-precessing arm needs more to draw the curve smoothly
+  const substeps = Math.min(8, Math.max(1, Math.ceil(Math.abs(driftDeg) / 2)));
+  const extensionPath: ArmPoint[] = [];
+  const totalSamples = numPredictions * substeps;
+  for (let s = 1; s <= totalSamples; s++) {
+    const index = lastPoint.index + (s / substeps) * stepsPerRotation;
+    extensionPath.push({ index, prime: predict(index) });
+  }
+
+  return { predictions, extensionPath };
 };
 
 // Detect spiral arms using RESIDUE CLASS grouping: arms are formed by primes
-// at indices k, k+N, k+2N, ... where N = stepsPerRotation = 360 / angleDelta
+// at indices k, k+N, k+2N, ... where N is the parastichy-dominant period
 export const detectSpiralArms = (
   primes: number[],
   stepsPerRotation: number,
-  numPredictions: number
+  numPredictions: number,
+  driftDeg: number
 ): SpiralArm[] => {
   if (primes.length < 3) return [];
 
@@ -346,11 +402,14 @@ export const detectSpiralArms = (
   armBuckets.forEach((points, armIndex) => {
     if (points.length >= 2) {
       const predict = makeArmPredictor(base, points);
-      arms.push({
-        armIndex,
+      const { predictions, extensionPath } = predictArmExtension(
         points,
-        predictions: predictArmExtension(points, stepsPerRotation, numPredictions, predict),
-      });
+        stepsPerRotation,
+        numPredictions,
+        predict,
+        driftDeg
+      );
+      arms.push({ armIndex, points, predictions, extensionPath });
     }
   });
 


### PR DESCRIPTION
## Problem

The spiral-arm predictions didn't draw arms as spirals at most angles. The detector picked the **largest** continued-fraction convergent of Δ/360 — the most *exact* arm family, which is also the straightest and stubbiest:

- **Δ=35°** → "72 arms — exact rays": a starburst of 4-point stubs, when the eye plainly sees **10 arms spiraling at −10°/step**
- **Δ=34°** (reported) → 53 near-rays instead of 21 spirals
- **φ=137.508°** → 89 stubs instead of the 21-spiral parastichy family
- Accuracy collapsed too (6.94% at 35°) since each prediction step jumped a full 72-index period

## Fix

**Parastichy family selection** — the algorithm from phyllotaxis theory (Vogel/Ridley; the sunflower 21/34/55 mechanism): enumerate ALL semiconvergent denominators of Δ/360 and pick the family minimizing within-arm neighbor spacing (`hypot(radial step, r·drift)`) at a representative outer radius. This matches "trace arms from the outside by nearest neighbor," computed exactly.

**Smooth spiral extensions** — prediction extensions now sample the arm's *visual* path (angle advancing by drift per period step, with adaptive substeps). Previously fractional-index sampling through the standard mapper wound through every intermediate turn, scribbling multi-turn curves across the scene.

**Arm family chips** — pin any alternate family (e.g. the counter-rotating 34-parastichy at φ); Auto restores the dominant one. Families are real mathematics: at φ they're exactly the Fibonacci numbers.

## Validation

Standalone numeric check (9 assertions, all pass) + verified live in browser:

| Angle | Before | After |
|---|---|---|
| 36° | 10 exact rays | 10 exact rays (unchanged) |
| 35° | 72-ray starburst, 1.32% err | **10 spirals −10°/step, 0.27% err** |
| 34° | 53 near-rays | **21 spirals −6°/step, 0.32% err** |
| 137.508° n=300 | 89 stubs | **21 spirals** |
| 137.508° n=2000 | 89 stubs | **55 spirals** (Fibonacci ladder climbs with n, like a real sunflower) |
| 90° / 1° | — | 4 rays / single spiral |

## Test plan
- [x] `npm run build` clean
- [x] Browser-verified all angles above with predictions on (screenshots in session)
- [x] Family chips switch live; Auto restores
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)